### PR TITLE
docker-compopse で発生するエラーに対応.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,14 @@ services:
       # これを指定しておかないと air でホットリロードが有効にならない
       - ./restapi/api:/api 
       #
+      # 2024/01/06
+      # 下記エラーが出るようになったので go_path の設定をコメントアウト
+      # ---
+      # Error:
+      #   ERROR: for restapi  Cannot start service api: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "air": executable file not found in $PATH: unknown
+      # ---
       # パッケージやバイナリファイルのインストール先（$GOPATH）を永続化
-      - go_path:/go
+      # - go_path:/go
 
   mysql:
     build: ./storage/

--- a/restapi/Dockerfile
+++ b/restapi/Dockerfile
@@ -1,12 +1,21 @@
 FROM golang:1.21.5
 
+# ENV GOPATH /go
+# ENV PATH /go/bin:$PATH
+
 WORKDIR /api
 COPY ./api /api
 
 RUN go get -u ./...
 RUN go mod tidy
-#RUN go get github.com/cosmtrek/air
+#
+# 2024/01/06
+# 下記エラーが出るようになったので air を明示的にインストールする
+# ---
+# Error:
+#   ERROR: for restapi  Cannot start service api: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "air": executable file not found in $PATH: unknown
+# ---
+RUN go install github.com/cosmtrek/air@latest
 
 # air による build と api の起動を行う
 CMD ["air", "-c", ".air.toml"]
-

--- a/restapi/api/go.mod
+++ b/restapi/api/go.mod
@@ -1,6 +1,6 @@
 module restapi
 
-go 1.19
+go 1.21.5
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1


### PR DESCRIPTION
エラー内容: 

```text
ERROR: for restapi  Cannot start service api: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "air": executable file not found in $PATH: unknown
```