### PR TITLE
下記エラーの対応で不要となったプロパティを削除.

### DIFF
--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -43,4 +43,3 @@ services:
     networks: 
       backend-work-net:
         ipv4_address: 172.30.10.100
- 

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -20,9 +20,6 @@ services:
       # ローカルとコンテナのディレクトリをバインドマウント（同期）
       # これを指定しておかないと air でホットリロードが有効にならない
       - ./restapi/api:/api 
-      #
-      # パッケージやバイナリファイルのインストール先（$GOPATH）を永続化
-      - go_path:/go
     hostname: restapi
     networks: 
       backend-work-net:
@@ -47,6 +44,3 @@ services:
       backend-work-net:
         ipv4_address: 172.30.10.100
  
-volumes:
-  go_path:
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,15 +23,6 @@ services:
       # ローカルとコンテナのディレクトリをバインドマウント（同期）
       # これを指定しておかないと air でホットリロードが有効にならない
       - ./restapi/api:/api 
-      #
-      # 2024/01/06
-      # 下記エラーが出るようになったので go_path の設定をコメントアウト
-      # ---
-      # Error:
-      #   ERROR: for restapi  Cannot start service api: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "air": executable file not found in $PATH: unknown
-      # ---
-      # パッケージやバイナリファイルのインストール先（$GOPATH）を永続化
-      # - go_path:/go
 
   mysql:
     build: ./storage/
@@ -62,8 +53,3 @@ services:
     networks:
       app-net:
         ipv4_address: 172.30.10.30
-
-volumes:
-  go_path:
-
- 


### PR DESCRIPTION
`ERROR: for restapi  Cannot start service api: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "air": executable file not found in $PATH: unknown`